### PR TITLE
[ :wrench: | #7 | Fix ] 찜 기능, 초기 화면 전국 데이터 띄우기 완료

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,17 +5,20 @@
 
 <h3>오늘 한 작업</h3>
 <ul>
-<li>카카오맵 api key 발급 & detailPage에 지도 불러오기</li>
-<li>한국 관광공사 api의 contentid와 카카오맵 api의 위도, 경도 정보 연결하여 해당 축제 위치 마커로 노출하기</li>
-<li>축제 상태(진행중, D-일수, 종료)를 3가지로 나타내기 위해서 "진행중인 행사", "개최 예정인 행사", "종료된 행사" 필터링이 필요할 것 같아 버튼 ui 추가하고 오늘 날짜로부터 api response 변수인 eventstartdate, eventenddate 계산하여 값 비교 후 상태 띄우기</li>
-<li>이미지가 null인 경우 로고 이미지로 대체</li>
-<li>글이 길어질 경우 detailPage가 상단부터 안보이고 중간부터 보이는 문제를 해결하기 위해 useEffect에 window.scrollTo(0,0) 적용</li>
+<li>WishIcon 컴포넌트에 props 전달 올바르게 수정하여 기능이 제대로 동작하도록 함</li>
+<li>Header에 있는 "전체" 버튼을 클릭했을 때 undefined가 뜨며 에러가 발생하는 부분을 해결하고, 처음 접속했을 때 "전체" 버튼이 클릭된 상태이며, 전국의 축제 데이터가 뜨게 함
+-> 전달받은 상태의 변수 areaCode가 "all"일 때 set 함수가 빈 문자열이도록 함</li>
+<li>WishListPage에 찜한 축제 카드들만 렌더링하기 위해 CardList.jsx에 props로 clickWishIcon: false로 주고, WishListPage에 clickWishIcon: true로 줌</li>
+<li>또한 cardList.jsx의 filter 함수에서 filter 메서드를 이용해 store에서 관리하고 있는 wishList에 클릭한 card.contentid를 넘겨줌</li>
+<li>찜 목록에서 찜 아이콘을 토글하여 찜해제를 할 경우, 페이지에서 바로 사라질 수 있도록 useEffect의 의존성배열에 wishList 넣어줌</li>
 </ul>
 <h3>내일 할 일</h3>
 <ul>
-<li>헤더 지역 클릭하면 클릭한 지역 코드에 해당하는 카드 리스트만 렌더링</li>
-<li>찜한 카드 리스트들만 위시리스트 페이지로 보내기</li>
+<li>detailPage에서 "주변" 둘러보기 컴포넌트 작업</li>
+<li>축제 검색 페이지</li>
 <li>카드리스트 무한스크롤 적용하기</li>
+<li>zustand 상태관리 정리</li>
+<li>vercel 배포</li>
 </ul>
 <br />
 

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,14 +1,17 @@
 import { useNavigate } from "react-router-dom";
-
 import { useFestivalWishStore } from "../store/festivalWishStore";
-
 import { FestivalState, WishIcon } from "./ui/icon";
 import festivalNullImg from "../assets/images/festivalNullImg.png";
 
 export default function Card({ card }) {
   const navigate = useNavigate();
-
   const { wishList, toggleWish } = useFestivalWishStore();
+
+  // firstimage에서 .png, .jpg, .jpeg까지의 문자열만 추출하는 함수
+  const extractImageUrl = (url) => {
+    const match = url.match(/https?:\/\/[^\s",]+/);
+    return match ? match[0] : festivalNullImg;
+  };
 
   const handleCard = () => {
     navigate(`/detail/${card.contentid}`, {
@@ -16,29 +19,25 @@ export default function Card({ card }) {
     });
   };
 
+  const handleWishIcon = () => {
+    toggleWish(card.contentid);
+  };
+
   return (
-    <div className=" w-[315px] relative pt-2 pb-5 cursor-pointer">
+    <div className="w-[315px] relative pt-2 pb-5 cursor-pointer">
       <div className="flex justify-between absolute w-full p-3">
         <FestivalState card={card} />
         <WishIcon
-          isWished={wishList[card.contentid]}
-          toggleWish={() => toggleWish(card.contentid)}
+          clickWish={wishList[card.contentid]}
+          handleWishIcon={handleWishIcon}
         />
       </div>
       <div className="w-[315px] h-52" onClick={() => handleCard()}>
-        {card.firstimage !== "" ? (
-          <img
-            src={card.firstimage}
-            alt="축제이미지"
-            className="w-full h-full object-cover rounded-lg"
-          />
-        ) : (
-          <img
-            src={festivalNullImg}
-            alt="firstimage없을 경우 대체 사진"
-            className="w-full h-full object-cover rounded-lg"
-          />
-        )}
+        <img
+          src={extractImageUrl(card.firstimage)}
+          alt="축제이미지"
+          className="w-full h-full object-cover rounded-lg"
+        />
       </div>
       <div className="mt-3" onClick={() => handleCard()}>
         <p className="text-base font-bold mt-0.5">{card.title}</p>

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -1,22 +1,24 @@
 import { useEffect, useState } from "react";
 import { getFestivalCards } from "../network/FestivalApi";
 import useFestivalCardStore from "../store/festivalCardStore";
+import useFestivalRegionStore from "../store/festivalRegionStore";
 import Card from "./Card";
-// import useFestivalRegionStore from "../store/festivalRegionStore";
+import { useFestivalWishStore } from "../store/festivalWishStore";
 
-export default function CardList() {
+export default function CardList({ clickWishIcon = false }) {
   // TODO: 무한스크롤 구현
-  const { festivalCards, setFestivalCards, selectedAreaCode } =
-    useFestivalCardStore();
-  // const { regionList, selectedRegion, setRegionList, setSelectedRegion } =
-  //   useFestivalRegionStore();
+  const { festivalCards, setFestivalCards } = useFestivalCardStore();
   const [selectFestivalStatus, setSelectFestivalStatus] = useState("");
   const [filteredCards, setFilteredCards] = useState([]);
+  const { selectedRegion } = useFestivalRegionStore();
+  const { wishList } = useFestivalWishStore();
 
   const fetchFestivalCards = async (areaCode) => {
     try {
-      const cards = await getFestivalCards(areaCode);
-      console.log(cards);
+      const cards =
+        areaCode === "all"
+          ? await getFestivalCards("")
+          : await getFestivalCards(areaCode);
 
       setFestivalCards(cards);
       setFilteredCards(cards);
@@ -35,7 +37,7 @@ export default function CardList() {
       return;
     }
 
-    const filtered = festivalCards.filter((card) => {
+    let filtered = festivalCards.filter((card) => {
       if (selectFestivalStatus === "진행중") {
         return (
           card.eventstartdate <= todayString && todayString <= card.eventenddate
@@ -50,18 +52,22 @@ export default function CardList() {
       return true; // 기본적으로 모든 카드를 반환
     });
 
+    if (clickWishIcon) {
+      filtered = filtered.filter((card) => wishList[card.contentid]);
+    }
+
     setFilteredCards(filtered);
   };
 
   useEffect(() => {
-    if (selectedAreaCode) {
-      fetchFestivalCards(selectedAreaCode);
+    if (selectedRegion) {
+      fetchFestivalCards(selectedRegion);
     }
-  }, [selectedAreaCode]);
+  }, [selectedRegion]);
 
   useEffect(() => {
     filterCards();
-  }, [festivalCards, selectFestivalStatus]);
+  }, [festivalCards, selectFestivalStatus, wishList]);
 
   return (
     <>

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -6,9 +6,6 @@ import useThemeStore from "../store/darkModeStore";
 import useFestivalRegionStore from "../store/festivalRegionStore";
 
 import { CloseIcon, DarkModeIcon } from "./ui/icon";
-import useFestivalCardStore from "../store/festivalCardStore";
-
-// const allRegionOption = { name: "전체", code: "all", rnum: 0 };
 
 export default function Header() {
   const location = useLocation();
@@ -18,7 +15,6 @@ export default function Header() {
   const toggleDarkMode = useThemeStore((state) => state.toggleDarkMode);
   const { regionList, setRegionList, selectedRegion, setSelectedRegion } =
     useFestivalRegionStore();
-  const { setSelectedAreaCode } = useFestivalCardStore();
 
   const fetchRegions = async () => {
     try {
@@ -64,8 +60,6 @@ export default function Header() {
 
   // 지역을 클릭했을 때 areaCode로 API 요청
   const handleRegionClick = async (code) => {
-    // console.log("region", code);
-    setSelectedAreaCode(code);
     setSelectedRegion(code);
   };
 

--- a/src/features/NoneItemPage/NoneItemPage.jsx
+++ b/src/features/NoneItemPage/NoneItemPage.jsx
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+
+export default function NoneItemPage() {
+  return (
+    <div className="flex flex-col items-center justify-center h-screen text-center">
+      <h1 className="text-3xl font-bold mb-4">아직 위시리스트가 비어있네요!</h1>
+      <p className="text-md mb-8">
+        마음에 드는 축제를 찾아 위시리스트에 추가해보세요.
+      </p>
+      <Link
+        to="/"
+        className="text-blue-500 hover:underline text-lg font-medium"
+      >
+        축제 구경하러 가기
+      </Link>
+    </div>
+  );
+}

--- a/src/features/WishListPage/WishListPage.jsx
+++ b/src/features/WishListPage/WishListPage.jsx
@@ -1,6 +1,12 @@
 import CardList from "../../components/CardList";
+import { useFestivalWishStore } from "../../store/festivalWishStore";
+import NoneItemPage from "../NoneItemPage/NoneItemPage";
 
 export default function WishListPage() {
-  // TODO: 찜버튼 클릭된 것들만 리스트 렌더링
-  return <CardList />;
+  const { wishList } = useFestivalWishStore();
+
+  // wishList가 비어있는지 확인
+  const hasWishedItems = Object.keys(wishList).length > 0;
+
+  return !hasWishedItems ? <NoneItemPage /> : <CardList clickWishIcon={true} />;
 }

--- a/src/store/festivalCardStore.jsx
+++ b/src/store/festivalCardStore.jsx
@@ -2,14 +2,9 @@ import { create } from "zustand";
 
 const useFestivalCardStore = create((set) => ({
   festivalCards: JSON.parse(localStorage.getItem("festivalCards")) || [],
-  selectedAreaCode: localStorage.getItem("selectAreaCode") || "",
   setFestivalCards: (cards) => {
     set({ festivalCards: cards });
     localStorage.setItem("festivalCards", JSON.stringify(cards));
-  },
-  setSelectedAreaCode: (areaCode) => {
-    set({ selectedAreaCode: areaCode });
-    localStorage.setItem("selectedAreaCode", JSON.stringify(areaCode));
   },
 }));
 

--- a/src/store/festivalWishStore.jsx
+++ b/src/store/festivalWishStore.jsx
@@ -1,12 +1,17 @@
 import { create } from "zustand";
 
 export const useFestivalWishStore = create((set) => ({
-  wishList: {},
-  toggleWish: (contentid) =>
-    set((state) => ({
-      wishList: {
-        ...state.wishList,
-        [contentid]: !state.wishList[contentid],
-      },
-    })),
+  wishList: JSON.parse(localStorage.getItem("wishList")) || {},
+  toggleWish: (contentid) => {
+    set((state) => {
+      const updateWishList = { ...state.wishList };
+      if (updateWishList[contentid]) {
+        delete updateWishList[contentid];
+      } else {
+        updateWishList[contentid] = true;
+      }
+      localStorage.setItem("wishList", JSON.stringify(updateWishList));
+      return { wishList: updateWishList };
+    });
+  },
 }));


### PR DESCRIPTION
## 🔎 작업 내용

- WishIcon 컴포넌트에 props 전달 올바르게 수정하여 기능이 제대로 동작하도록 함
- Header에 있는 "전체" 버튼을 클릭했을 때 undefined가 뜨며 에러가 발생하는 부분을 해결하고, 처음 접속했을 때 "전체" 버튼이 클릭된 상태이며, 전국의 축제 데이터가 뜨게 함
-> 전달받은 상태의 변수 areaCode가 "all"일 때 set 함수가 빈 문자열이도록 함
- WishListPage에 찜한 축제 카드들만 렌더링하기 위해 CardList.jsx에 props로 clickWishIcon: false로 주고, WishListPage에 clickWishIcon: true로 줌
- 또한  cardList.jsx의 filter 함수에서 filter 메서드를 이용해 store에서 관리하고 있는 wishList에 클릭한 card.contentid를 넘겨줌
- 찜 목록에서 찜 아이콘을 토글하여 찜해제를 할 경우, 페이지에서 바로 사라질 수 있도록 useEffect의 의존성배열에 wishList 넣어줌

  <br/>

### 작업 결과 (관련 스크린샷)

<img src="https://github.com/user-attachments/assets/b079e7ac-29b5-4ee3-ba39-b6ebdbf748f7" width="50%" height="50%"/>
<img src="https://github.com/user-attachments/assets/dd742eae-1deb-45ee-a57a-50f5ca7ab18b" width="50%" height="50%"/>


<br/>

## 🔧 앞으로의 작업

- detailPage에서 "주변" 둘러보기 컴포넌트 작업
- 축제 검색 페이지
- 카드리스트 무한스크롤
- zustand 상태관리 정리
- vercel 배포
